### PR TITLE
Increase MaxLength constraint for 'YourIPAddress' from 15 to 18

### DIFF
--- a/DatabaseMigration_CFN_Template.yaml
+++ b/DatabaseMigration_CFN_Template.yaml
@@ -116,7 +116,7 @@ Parameters:
     Description: "Enter your IP address in the form x.x.x.x/32  You can find your IP on this website http://ipinfo.io/ip"
     Type: String
     MinLength: 4
-    MaxLength: 15
+    MaxLength: 18
     AllowedPattern: "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})"
     ConstraintDescription: Must be a valid IP address in the form x.x.x.x/32
     Default: 0.0.0.0/0


### PR DESCRIPTION
IP Addresses in the xxx.xxx.xxx.xxx/32 format require 18 digits. The CloudFormation script would not accept my IP address because it was 17 digits long.

*Issue #, if available:*

*Description of changes:*
Increase MaxLength constraint for 'YourIPAddress' from 15 to 18

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
